### PR TITLE
Fix recurrent Laplace basis autograd

### DIFF
--- a/Model/laptrans.py
+++ b/Model/laptrans.py
@@ -172,8 +172,8 @@ class LearnableLaplacianBasis(nn.Module):
         u = self.proj(x)                     # [B,T,k]
 
         # z_t = rho_t * e^{i theta_t} * z_{t-1} + u_t
-        C = torch.empty(B, T, k, dtype=u.dtype, device=device)
-        S = torch.empty(B, T, k, dtype=u.dtype, device=device)
+        c_hist = []
+        s_hist = []
         c = torch.zeros(B, k, dtype=u.dtype, device=device)
         s = torch.zeros(B, k, dtype=u.dtype, device=device)
         for t in range(T):
@@ -181,7 +181,11 @@ class LearnableLaplacianBasis(nn.Module):
             ct = cos_t[:, t, :]
             st = sin_t[:, t, :]
             c, s = rt * (c * ct - s * st) + u[:, t, :], rt * (c * st + s * ct)
-            C[:, t, :], S[:, t, :] = c, s
+            c_hist.append(c)
+            s_hist.append(s)
+
+        C = torch.stack(c_hist, dim=1)
+        S = torch.stack(s_hist, dim=1)
 
         return torch.cat([C, S], dim=2).contiguous()
 

--- a/tests/test_laptrans.py
+++ b/tests/test_laptrans.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+torch = pytest.importorskip("torch")
+
+
+from Model.laptrans import LearnableLaplacianBasis
+
+
+def test_recurrent_laplacian_basis_backpropagates_to_parameters():
+    torch.manual_seed(0)
+    basis = LearnableLaplacianBasis(k=3, feat_dim=5, mode="recurrent")
+    x = torch.randn(2, 4, 5)
+
+    output = basis(x)
+    loss = output.sum()
+    loss.backward()
+
+    assert basis.proj.weight.grad is not None
+    assert basis._s_real_raw.grad is not None
+    assert basis.proj.weight.grad.abs().sum().item() > 0.0
+    assert basis._s_real_raw.grad.abs().sum().item() > 0.0


### PR DESCRIPTION
## Summary
- ensure the recurrent LearnableLaplacianBasis collects features through differentiable stacks instead of empty buffers
- add a regression test that checks gradients reach recurrent Laplace parameters (skipped if torch is unavailable)

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd1c1ab360832989cfecba1af17dfc