### PR TITLE
Refine Laplace transformer modules

### DIFF
--- a/Model/llapdit.py
+++ b/Model/llapdit.py
@@ -1,45 +1,51 @@
+"""Latent Laplace-DiT diffusion model."""
+
+from typing import List, Optional, Tuple, Union
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from typing import Optional, Union, List
+
+from Model.lapformer import LapFormer
 from Model.llapdit_utils import NoiseScheduler
 from Model.pos_time_emb import timestep_embedding
-from Model.lapformer import LapFormer
 
 
 class LLapDiT(nn.Module):
     """Latent Laplace-DiT for multivariate time series with global conditioning.
 
-    Expects an external (typically frozen) context module whose summaries are
-    passed in explicitly during training and sampling.
+    The model consumes noisy inputs together with optional external summaries
+    (e.g. from a frozen encoder) and predicts either the noise ``eps`` or the
+    velocity ``v`` depending on ``predict_type``.
     """
 
-    def __init__(self,
-                 data_dim: int,
-                 hidden_dim: int,
-                 num_layers: int,
-                 num_heads: int,
-                 *,
-                 predict_type: str = 'v',
-                 laplace_k: Union[int, List[int]] = 32,
-                 timesteps: int = 1000,
-                 schedule: str = 'cosine',
-                 dropout: float = 0.0,
-                 attn_dropout: float = 0.0,
-                 self_conditioning: bool = False,
-                 lap_mode_main: str = 'effective'
-                 ):
+    def __init__(
+        self,
+        data_dim: int,
+        hidden_dim: int,
+        num_layers: int,
+        num_heads: int,
+        *,
+        predict_type: str = "v",
+        laplace_k: Union[int, List[int]] = 32,
+        timesteps: int = 1000,
+        schedule: str = "cosine",
+        dropout: float = 0.0,
+        attn_dropout: float = 0.0,
+        self_conditioning: bool = False,
+        lap_mode_main: str = "effective",
+    ) -> None:
         super().__init__()
-        assert predict_type in ('eps', 'v')
-       
+        if predict_type not in {"eps", "v"}:
+            raise ValueError("predict_type must be either 'eps' or 'v'")
+
         self.predict_type = predict_type
         self.self_conditioning = bool(self_conditioning)
 
-        # diffusion utils (not used in forward path tests)
+        # Diffusion scheduler utilities (not exercised in forward-only tests).
         self.scheduler = NoiseScheduler(timesteps=timesteps, schedule=schedule)
 
-        # main LapFormer (mode tied to summarizer)
-
+        # Main LapFormer backbone (mode tied to external summariser if any).
         self.model = LapFormer(
             input_dim=data_dim,
             hidden_dim=hidden_dim,
@@ -58,77 +64,116 @@ class LLapDiT(nn.Module):
     # Embeddings & conditioning
     # -------------------------------
     def _time_embed(self, t: torch.Tensor) -> torch.Tensor:
+        """Return a SiLU-activated sinusoidal embedding for diffusion steps."""
+
         te = timestep_embedding(t, self.time_dim)  # [B, H]
         return F.silu(te)
 
     # -------------------------------
     # Forward call
     # -------------------------------
-    def forward(self,
-                x_t: torch.Tensor,
-                t: torch.Tensor,
-                *,
-                series: Optional[torch.Tensor] = None,
-                series_mask: Optional[torch.Tensor] = None,
-                cond_summary: Optional[torch.Tensor] = None,
-                entity_ids: Optional[torch.Tensor] = None,
-                sc_feat: Optional[torch.Tensor] = None,
-                dt: Optional[torch.Tensor] = None,
-                series_dt: Optional[torch.Tensor] = None,
-                series_diff: Optional[torch.Tensor] = None) -> torch.Tensor:
-        """Predict native param ('eps' or 'v') at timestep t for x_t."""
+    def forward(
+        self,
+        x_t: torch.Tensor,
+        t: torch.Tensor,
+        *,
+        series: Optional[torch.Tensor] = None,
+        series_mask: Optional[torch.Tensor] = None,
+        cond_summary: Optional[torch.Tensor] = None,
+        entity_ids: Optional[torch.Tensor] = None,
+        sc_feat: Optional[torch.Tensor] = None,
+        dt: Optional[torch.Tensor] = None,
+        series_dt: Optional[torch.Tensor] = None,
+        series_diff: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Predict ``eps`` or ``v`` for a batch of noisy inputs ``x_t``.
+
+        The method delegates temporal reasoning to :class:`LapFormer`.  Only the
+        externally supplied ``cond_summary`` is consumed for conditioning; the
+        legacy in-module summarisation hooks now raise informative errors.
+        """
+
         if cond_summary is None:
-            if any(arg is not None for arg in (series, series_mask, entity_ids, series_dt, series_diff)):
+            if any(
+                arg is not None
+                for arg in (series, series_mask, entity_ids, series_dt, series_diff)
+            ):
                 raise ValueError(
                     "LLapDiT no longer builds conditioning internally. "
                     "Provide `cond_summary` from a pre-trained summarizer."
                 )
         t_emb = self._time_embed(t).to(x_t.dtype)
         # Pass dt to LapFormer (only used when lap_mode='recurrent')
-        raw = self.model(x_t, t_emb, cond_summary=cond_summary, sc_feat=sc_feat, dt=dt)
-        return raw
+        return self.model(
+            x_t,
+            t_emb,
+            cond_summary=cond_summary,
+            sc_feat=sc_feat,
+            dt=dt,
+        )
 
     # -------------------------------
     # Sampling
     # -------------------------------
-
     @torch.no_grad()
     def generate(
-            self,
-            shape,
-            steps: int = 36,
-            guidance_strength=2.0,
-            guidance_power: float = 2.0,
-            eta: float = 0.0,
-            *,
-            series=None,
-            series_mask=None,
-            cond_summary=None,
-            entity_ids=None,
-            y_obs: torch.Tensor = None,
-            obs_mask: torch.Tensor = None,
-            dt: Optional[torch.Tensor] = None,
-            series_dt: Optional[torch.Tensor] = None,
-            series_diff: Optional[torch.Tensor] = None,
-            cfg_rescale: bool = True,
-            self_cond: bool = False,
-            rho: float = 7.5,
-            dynamic_thresh_p: float = 0,
-            dynamic_thresh_max: float = 1.0,
-    ):
+        self,
+        shape: Tuple[int, int, int],
+        steps: int = 36,
+        guidance_strength=2.0,
+        guidance_power: float = 2.0,
+        eta: float = 0.0,
+        *,
+        series: Optional[torch.Tensor] = None,
+        series_mask: Optional[torch.Tensor] = None,
+        cond_summary: Optional[torch.Tensor] = None,
+        entity_ids: Optional[torch.Tensor] = None,
+        y_obs: Optional[torch.Tensor] = None,
+        obs_mask: Optional[torch.Tensor] = None,
+        dt: Optional[torch.Tensor] = None,
+        series_dt: Optional[torch.Tensor] = None,
+        series_diff: Optional[torch.Tensor] = None,
+        cfg_rescale: bool = True,
+        self_cond: bool = False,
+        rho: float = 7.5,
+        dynamic_thresh_p: float = 0.0,
+        dynamic_thresh_max: float = 1.0,
+    ) -> torch.Tensor:
+        """Sample trajectories with DDIM+Karras schedule and optional CFG.
+
+        Args:
+            shape: Tuple ``(B, L, D)`` describing the desired sample batch.
+            steps: Number of denoising steps to take (``<= timesteps``).
+            guidance_strength: CFG strength (scalar or ``(min, max)`` schedule).
+            guidance_power: Exponent for scheduled CFG strength.
+            eta: DDIM stochasticity parameter.
+            series / series_mask / cond_summary / entity_ids: Optional conditioning
+                data. ``cond_summary`` must be provided when any of the others are.
+            y_obs / obs_mask: Optional observations for inpainting.
+            dt / series_dt / series_diff: Optional step-size metadata forwarded to
+                the Laplace backbone.
+            cfg_rescale: Whether to apply the CFG rescaling heuristic.
+            self_cond: Enable self-conditioning during sampling.
+            rho: Karras sigma schedule exponent.
+            dynamic_thresh_p / dynamic_thresh_max: Parameters for dynamic
+                thresholding of ``x0``.
+
+        Returns:
+            The final ``x0`` prediction corresponding to the denoised samples.
         """
-        Efficient DDIM sampler with Karras time selection and optional CFG rescale.
-        Returns x0 prediction. Keeps inpainting & self-conditioning support.
-        """
+
         device = next(self.parameters()).device
         B, L, D = shape
         T = int(self.scheduler.timesteps)
 
         # ---- build context once (dt/mask/diff aware) ----
-        if cond_summary is None and any(arg is not None for arg in (series, series_mask, series_dt, series_diff, entity_ids)):
+        if cond_summary is None and any(
+            arg is not None for arg in (series, series_mask, series_dt, series_diff, entity_ids)
+        ):
             raise ValueError(
                 "LLapDiT.generate requires `cond_summary` from the frozen summarizer; "
                 "internal summarizer construction has been removed."
+            )
 
         # ---- vectorized Karras step indices (descending) ----
         ab = self.scheduler.alpha_bars.to(device)
@@ -152,7 +197,12 @@ class LLapDiT(nn.Module):
         def _alpha_bar_batched(t_b: torch.Tensor) -> torch.Tensor:
             return self.scheduler._gather(self.scheduler.alpha_bars, t_b).view(B, 1, 1)
 
-        def _cfg(pred_u: torch.Tensor, pred_c: torch.Tensor, g_scalar: torch.Tensor, mask_scale=None) -> torch.Tensor:
+        def _cfg(
+            pred_u: torch.Tensor,
+            pred_c: torch.Tensor,
+            g_scalar: torch.Tensor,
+            mask_scale: Optional[torch.Tensor] = None,
+        ) -> torch.Tensor:
             if mask_scale is not None:
                 g_eff = (1.0 + (g_scalar - 1.0) * mask_scale).to(pred_u.dtype)
             else:
@@ -199,25 +249,43 @@ class LLapDiT(nn.Module):
 
             # unconditional / conditional passes
             pred_u = self.forward(
-                x_t, t_b,
-                series=None, series_mask=None, cond_summary=None,
+                x_t,
+                t_b,
+                series=None,
+                series_mask=None,
+                cond_summary=None,
                 sc_feat=sc_feat_next if self_cond else None,
-                entity_ids=entity_ids, dt=dt, series_dt=series_dt, series_diff=series_diff
+                entity_ids=entity_ids,
+                dt=dt,
+                series_dt=series_dt,
+                series_diff=series_diff,
             )
             pred_c = self.forward(
-                x_t, t_b,
-                series=series, series_mask=series_mask, cond_summary=cond_summary,
+                x_t,
+                t_b,
+                series=series,
+                series_mask=series_mask,
+                cond_summary=cond_summary,
                 sc_feat=sc_feat_next if self_cond else None,
-                entity_ids=entity_ids, dt=dt, series_dt=series_dt, series_diff=series_diff
+                entity_ids=entity_ids,
+                dt=dt,
+                series_dt=series_dt,
+                series_diff=series_diff,
             )
 
             # classifier-free guidance (optionally scheduled)
             if isinstance(guidance_strength, (tuple, list)):
                 g_min, g_max = guidance_strength
-                ab = _alpha_bar_batched(t_b)  # [B,1,1]
-                g_scalar = g_min + (g_max - g_min) * (1.0 - ab) ** guidance_power
+                ab_b = _alpha_bar_batched(t_b)  # [B,1,1]
+                g_min_t = torch.as_tensor(g_min, device=device, dtype=ab_b.dtype)
+                g_max_t = torch.as_tensor(g_max, device=device, dtype=ab_b.dtype)
+                g_scalar = g_min_t + (g_max_t - g_min_t) * (1.0 - ab_b) ** guidance_power
             else:
-                g_scalar = torch.as_tensor(float(guidance_strength), device=device).view(1, 1, 1).expand(B, 1, 1)
+                g_scalar = (
+                    torch.as_tensor(float(guidance_strength), device=device)
+                    .view(1, 1, 1)
+                    .expand(B, 1, 1)
+                )
 
             pred = _cfg(pred_u, pred_c, g_scalar, mask_scale=tar_scale)
 
@@ -234,16 +302,26 @@ class LLapDiT(nn.Module):
             # time update
             if int(t_prev_i) >= 0:
                 tprev_b = torch.full((B,), int(t_prev_i.item()), device=device, dtype=torch.long)
-                x_t = self.scheduler.ddim_step_from(x_t, t_b, tprev_b, pred, param_type=self.predict_type, eta=eta)
+                x_t = self.scheduler.ddim_step_from(
+                    x_t,
+                    t_b,
+                    tprev_b,
+                    pred,
+                    param_type=self.predict_type,
+                    eta=eta,
+                )
             else:
                 x_t = x0_hat
 
             # keep observed values consistent across steps
             if (y_obs is not None) and (obs_u is not None):
                 if int(t_prev_i) >= 0:
-                    x_obs_t, _ = self.scheduler.q_sample(y_obs.to(device=device, dtype=x_t.dtype), tprev_b)
+                    x_obs_t, _ = self.scheduler.q_sample(
+                        y_obs.to(device=device, dtype=x_t.dtype), tprev_b
+                    )
                     x_t = obs_u * x_obs_t + (1.0 - obs_u) * x_t
                 else:
                     x_t = obs_u * y_obs.to(device=device, dtype=x_t.dtype) + (1.0 - obs_u) * x_t
 
         return last_x0 if last_x0 is not None else x_t
+


### PR DESCRIPTION
## Summary
- allow LapFormer attention blocks to run without conditioning vectors and document interfaces
- restructure LLapDiT with richer documentation, explicit validation, and typed CFG scheduling
- add comprehensive docstrings and clean imports for the Laplace diffusion stack

## Testing
- python -m compileall Model/laptrans.py Model/lapformer.py Model/llapdit.py

------
https://chatgpt.com/codex/tasks/task_e_68de7fa075d8832992c6c69dd5b851aa