### PR TITLE
Improve diffusion utilities and summarizer documentation

### DIFF
--- a/Model/summarizer.py
+++ b/Model/summarizer.py
@@ -18,6 +18,7 @@ from Model.laptrans import LearnableLaplaceBasis, LearnablepesudoInverse  # note
 
 
 class TVHead(nn.Module):
+    """Single-hidden-layer MLP that projects features to scalar signals."""
 
     def __init__(self, feat_dim: int, hidden: int = 32) -> None:
         super().__init__()
@@ -29,23 +30,26 @@ class TVHead(nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Return scalar activations with shape ``[..., 1]`` squeezed to ``[...]``."""
+
         return self.net(x).squeeze(-1)
 
 
 class LaplaceAE(nn.Module):
+    """Lightweight Laplace auto-encoder for panel data summarisation."""
 
     def __init__(
-            self,
-            num_entities: int,
-            feat_dim: int,
-            window_size: int,
-            *,
-            lap_k: int = 8,
-            tv_hidden: int = 32,
-            out_len: int = 16,
-            context_dim: int = 256,
-            dropout: float = 0.0,
-    ):
+        self,
+        num_entities: int,
+        feat_dim: int,
+        window_size: int,
+        *,
+        lap_k: int = 8,
+        tv_hidden: int = 32,
+        out_len: int = 16,
+        context_dim: int = 256,
+        dropout: float = 0.0,
+    ) -> None:
         super().__init__()
         self.N = num_entities
         self.D = feat_dim
@@ -92,13 +96,27 @@ class LaplaceAE(nn.Module):
         return se.sum() / denom
 
     def forward(
-            self,
-            x: torch.Tensor,  # [B,K,N,D]   (V series)
-            pad_mask: Optional[torch.Tensor] = None,  # unused (keep signature)
-            dt: Optional[torch.Tensor] = None,  #
-            ctx_diff: Optional[torch.Tensor] = None,  # [B,K,N,D] (T series)
-            entity_mask: Optional[torch.Tensor] = None,
+        self,
+        x: torch.Tensor,
+        pad_mask: Optional[torch.Tensor] = None,  # unused (keep signature)
+        dt: Optional[torch.Tensor] = None,
+        ctx_diff: Optional[torch.Tensor] = None,
+        entity_mask: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
+        """Encode V/T-series panels into context tokens and auxiliaries.
+
+        Args:
+            x: Value series with shape ``[B, K, N, D]``.
+            pad_mask: Present for API compatibility; ignored.
+            dt: Unused placeholder for compatibility.
+            ctx_diff: Difference/temporal series ``[B, K, N, D]``.
+            entity_mask: Boolean mask ``[B, N]`` identifying valid entities.
+
+        Returns:
+            context: Token summary ``[B, S, Hc]``.
+            aux: Dictionary containing reconstruction auxiliaries.
+        """
+
         if entity_mask is None:
             raise ValueError("entity_mask must be provided: [B,N] bool")
         if entity_mask.dtype != torch.bool:
@@ -116,6 +134,10 @@ class LaplaceAE(nn.Module):
                 f"entity_mask must be of shape [B,N]={B, N}, got {tuple(entity_mask.shape)}"
             )
         assert N == self.N and D == self.D, f"Got (N,D)=({N},{D}), expected ({self.N},{self.D})"
+        if K != self.window_size:
+            raise ValueError(
+                f"Input window length {K} does not match configured window_size {self.window_size}."
+            )
 
         # ---- Build scalar signals per entity (EFF-style) ----
         mask = entity_mask.to(dtype=x.dtype, device=x.device)
@@ -139,13 +161,14 @@ class LaplaceAE(nn.Module):
         tokens = self.token_proj(fused)  # [B,K,Hc]
         # Pool K→S with learned queries via simple attention scores
         # (no expensive MHA; just content-based pooling)
-        q = self.queries[None, :, :]  # [1,S,Hc]
-        att = torch.einsum('bkh,bsh->bks', self.norm(tokens), self.norm(q)) / math.sqrt(self.Hc)
+        norm_tokens = self.norm(tokens)
+        norm_queries = F.layer_norm(self.queries, (self.Hc,))  # [S,Hc]
+        att = torch.matmul(norm_tokens, norm_queries.t()) / math.sqrt(self.Hc)  # [B,K,S]
         att = att.softmax(dim=1)  # softmax over K
-        context = torch.einsum('bks,bkh->bsh', att, tokens)  # [B,S,Hc]
+        context = torch.matmul(att.transpose(1, 2), tokens)  # [B,S,Hc]
         context_pooled = context.mean(dim=1)  # Shape: [B, Hc]
         aux_recon = self.aux_decoder(context_pooled)  # Shape: [B, K*N*2]
-        aux_recon = aux_recon.view(B, self.window_size, self.N * 2)  # Reshape to [B, K, N*2]
+        aux_recon = aux_recon.view(B, K, self.N * 2)  # Reshape to [B, K, N*2]
 
         # Split into auxiliary v_hat and t_hat
         v_hat_aux, t_hat_aux = torch.chunk(aux_recon, 2, dim=-1)  # Both [B, K, N]
@@ -158,8 +181,14 @@ class LaplaceAE(nn.Module):
         }
         return context, aux
 
-    def recon_loss(self, aux: Dict[str, torch.Tensor], entity_mask: torch.Tensor, gamma: float = 1.0) -> torch.Tensor:
-        """Convenience helper for training scripts."""
+    def recon_loss(
+        self,
+        aux: Dict[str, torch.Tensor],
+        entity_mask: torch.Tensor,
+        gamma: float = 1.0,
+    ) -> torch.Tensor:
+        """Compute the combined Laplace and auxiliary reconstruction loss."""
+
         # Primary loss (trains the Laplace encoder/pseudoinverse)
         lv = self._masked_mse(aux['v_hat'], aux['v_sig'], entity_mask)
         lt = self._masked_mse(aux['t_hat'], aux['t_sig'], entity_mask)


### PR DESCRIPTION
## Summary
- add docstrings and type annotations to the LLapDiT diffusion helpers while tightening tensor reshaping logic
- document the LaplaceAE summariser, validate inputs, and simplify its pooling attention computation
- ensure auxiliary reconstructions use the runtime window length when reshaping for stability

## Testing
- python -m compileall Model/llapdit_utils.py Model/summarizer.py

------
https://chatgpt.com/codex/tasks/task_e_68de84c6aee0832983dd77006f1ef49b