### PR TITLE
Refactor latent and summarizer training pipelines

### DIFF
--- a/train_val_pipeline.py
+++ b/train_val_pipeline.py
@@ -1,13 +1,21 @@
-"""Unified training pipeline for the latent VAE and summarizer models."""
+"""Unified entrypoint to train the latent VAE followed by the summarizer."""
 
-from Dataset.fin_dataset import run_experiment
+from __future__ import annotations
+
+from typing import Tuple
+
 import crypto_config
+from Dataset.fin_dataset import run_experiment
 import train_val_latent
 import train_val_summarizer
+from torch.utils.data import DataLoader
 
 
-def prepare_dataloaders(config=crypto_config):
+def prepare_dataloaders(
+    config=crypto_config,
+) -> Tuple[DataLoader, DataLoader, DataLoader, Tuple[int, int, int]]:
     """Build train/val/test loaders using the shared configuration."""
+
     return run_experiment(
         data_dir=config.DATA_DIR,
         date_batching=config.date_batching,
@@ -18,7 +26,7 @@ def prepare_dataloaders(config=crypto_config):
     )
 
 
-def main():
+def main() -> None:
     print("Preparing data loaders...")
     train_loader, val_loader, test_loader, sizes = prepare_dataloaders()
 
@@ -31,9 +39,10 @@ def main():
         config=crypto_config,
     )
     print(
-        f"VAE checkpoint loaded from: {vae_stats['loaded_checkpoint']}\n"
-        f"Best β·ELBO checkpoint: {vae_stats['best_elbo_path']}\n"
-        f"Best recon checkpoint: {vae_stats['best_recon_path']}"
+        "VAE checkpoints:\n"
+        f"  loaded -> {vae_stats['loaded_checkpoint']}\n"
+        f"  best β·ELBO -> {vae_stats['best_elbo_path']}\n"
+        f"  best recon -> {vae_stats['best_recon_path']}"
     )
 
     print("\n=== Training Summarizer ===")
@@ -45,11 +54,12 @@ def main():
         config=crypto_config,
     )
     print(
-        f"Summarizer best val loss: {summarizer_stats['best_val']:.6f}\n"
-        f"Summarizer test loss: {summarizer_stats['test_loss']:.6f}\n"
-        f"Checkpoint: {summarizer_stats['checkpoint']}"
+        "Summarizer results:\n"
+        f"  best val loss -> {summarizer_stats['best_val']:.6f}\n"
+        f"  test loss -> {summarizer_stats['test_loss']:.6f}\n"
+        f"  checkpoint -> {summarizer_stats['checkpoint']}"
     )
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()


### PR DESCRIPTION
## Summary
- refactor the latent VAE training script with reusable helpers, richer logging, and safer checkpoint handling
- streamline summarizer training with shared batch preparation, device-aware AMP usage, and consistent metrics
- polish the combined pipeline entrypoint and reporting for both training stages

## Testing
- python -m compileall train_val_latent.py train_val_summarizer.py train_val_pipeline.py


------
https://chatgpt.com/codex/tasks/task_e_68dea0024ee48329b3ce3426f402af03