### PR TITLE
Remove redundant checkpoint artifacts from VAE and summarizer training

### DIFF
--- a/train_val_summarizer.py
+++ b/train_val_summarizer.py
@@ -245,8 +245,6 @@ def run(
             print(f"\nEarly stopping at epoch {epoch}: validation loss plateaued.")
             break
 
-    save_ckpt(ckpt_path.with_suffix(".final.pt"), model, {"best_val": best_val, "best_epoch": best_epoch})
-
     if ckpt_path.exists():
         state = torch.load(ckpt_path, map_location=device)
         model.load_state_dict(state["model"])
@@ -266,7 +264,6 @@ def run(
         "best_val": best_val,
         "test_loss": test_loss,
         "checkpoint": str(ckpt_path),
-        "final_checkpoint": str(ckpt_path.with_suffix(".final.pt")),
     }
 
 


### PR DESCRIPTION
## Summary
- stop writing the latent VAE "last.pt" checkpoint and reuse the trained model when no best checkpoints are available
- remove the summarizer's "final.pt" artifact, keeping only the tracked best checkpoint state

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68deb658b4b8832993859747231b1c0d