### PR TITLE
Fix PathLike typing compatibility

### DIFF
--- a/Dataset/bms_air_dataset.py
+++ b/Dataset/bms_air_dataset.py
@@ -22,7 +22,7 @@ import shutil
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Union
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, TYPE_CHECKING, Union
 
 import numpy as np
 import pandas as pd
@@ -44,7 +44,12 @@ DATA_URL = (
 ARCHIVE_ROOT = "PRSA_Data_20130301-20170228"
 TARGET_COLUMN = "PM2.5"
 
-PathLike = Union[str, os.PathLike[str]]
+if TYPE_CHECKING:
+    from os import PathLike as _PathLike
+
+    PathLike = Union[str, _PathLike[str]]
+else:
+    PathLike = Union[str, os.PathLike]
 
 
 @dataclass

--- a/Dataset/fin_dataset.py
+++ b/Dataset/fin_dataset.py
@@ -20,14 +20,19 @@ import os
 from dataclasses import dataclass, field
 from math import ceil as _ceil
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 import pandas as pd
 import torch
 from torch.utils.data import DataLoader, Dataset, Sampler as _Sampler
 
-PathLike = Union[str, os.PathLike[str]]
+if TYPE_CHECKING:
+    from os import PathLike as _PathLike
+
+    PathLike = Union[str, _PathLike[str]]
+else:
+    PathLike = Union[str, os.PathLike]
 
 # --------------------- Public configs (kept compatible) ---------------------
 


### PR DESCRIPTION
## Summary
- avoid subscripting `os.PathLike` at runtime in both dataset modules
- gate the generic `PathLike` alias behind `TYPE_CHECKING` for type checkers

## Testing
- python -m compileall Dataset/fin_dataset.py Dataset/bms_air_dataset.py

------
https://chatgpt.com/codex/tasks/task_e_68e15d2c14948329b3ff63845c85ef5e