### PR TITLE
Add NOAA ISD dataset utilities compatible with shared pipeline

### DIFF
--- a/Dataset/nnoa_isd_dataset.py
+++ b/Dataset/nnoa_isd_dataset.py
@@ -1,86 +1,588 @@
-import isd
+"""NOAA ISD (Integrated Surface Database) dataset utilities.
+
+This module mirrors the public API provided by :mod:`Dataset.fin_dataset` and
+:mod:`Dataset.bms_air_dataset` so that downstream training code can reuse the
+same dataloading pipeline across heterogeneous domains.  The helper functions
+construct the compact cache layout used by :func:`fin_dataset.prepare_features_and_index_cache`
+consisting of per-station feature/target matrices and a global window index.
+
+The target series ``Y`` corresponds to future values of the ambient air
+``temperature`` (degrees Celsius).  Context features ``X`` include the current
+and historical readings for several meteorological variables such as dew point,
+wind speed and sea level pressure.  All arrays are written in float16 for
+storage efficiency; normalization statistics are computed either globally or
+per station depending on the configuration.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, TYPE_CHECKING, Union
+
+import numpy as np
 import pandas as pd
-from tqdm.auto import tqdm # For a nice progress bar
+
+try:  # Optional dependency used for downloading raw ISD measurements
+    import isd  # type: ignore
+except Exception:  # pragma: no cover - handled gracefully at runtime
+    isd = None
+
+from .fin_dataset import (
+    CachePaths,
+    load_dataloaders_with_ratio_split as _load_fin_ratio_split,
+    rebuild_window_index_only as _rebuild_window_index_only,
+)
+
+if TYPE_CHECKING:
+    from os import PathLike as _PathLike
+
+    PathLike = Union[str, _PathLike[str]]
+else:
+    PathLike = Union[str, os.PathLike]
 
 
-# Get a list of all stations in the ISD inventory
-stations = isd.get_stations()
+TARGET_COLUMN = "temperature"
+DEFAULT_FEATURE_COLUMNS: Tuple[str, ...] = (
+    "temperature",
+    "dew_point",
+    "sea_level_pressure",
+    "wind_speed",
+    "precipitation",
+)
 
-# Filter for stations in Great Britain (country code 'UK') that were active in 2022
-uk_stations_2022 = stations[
-    (stations['country'] == 'UK') &
-    (stations['begin'] <= '2022-01-01') &
-    (stations['end'] >= '2022-12-31')
+
+@dataclass
+class ISDCacheConfig:
+    """Configuration used when preparing the compact ISD cache."""
+
+    window: int
+    horizon: int
+    years: Sequence[int]
+    data_dir: PathLike = "./nnoa_isd_cache"
+    raw_data_dir: Optional[PathLike] = "./nnoa_isd_raw"
+    country: Optional[str] = "UK"
+    stations: Optional[Sequence[str]] = None
+    feature_columns: Optional[Sequence[str]] = None
+    normalize_per_station: bool = True
+    clamp_sigma: float = 5.0
+    keep_time_meta: str = "end"  # "full" | "end" | "none"
+    freq: str = "H"
+    min_coverage: float = 0.85
+    max_stations: Optional[int] = None
+    overwrite: bool = False
+
+
+def _require_isd() -> None:
+    if isd is None:
+        raise ImportError(
+            "The 'isd' package is required to download NOAA ISD data. Install via 'pip install isd'."
+        )
+
+
+def list_isd_stations(
+    *,
+    country: Optional[str] = None,
+    start_year: Optional[int] = None,
+    end_year: Optional[int] = None,
+    stations: Optional[Sequence[str]] = None,
+    max_stations: Optional[int] = None,
+) -> pd.DataFrame:
+    """Retrieve and filter the ISD station inventory.
+
+    Parameters
+    ----------
+    country:
+        Restrict the inventory to a specific ISO country code (e.g. ``"UK"``).
+    start_year, end_year:
+        Only keep stations that were active for *all* requested years.
+    stations:
+        Optional explicit station identifiers in ``USAFWBAN`` format.  When
+        provided the inventory is filtered to this set.
+    max_stations:
+        Limit the number of stations returned after filtering.  Useful for quick
+        experiments.
+    """
+
+    _require_isd()
+
+    inv = isd.get_stations()  # type: ignore[call-arg]
+    inv = inv.copy()
+    inv.columns = [str(c).lower() for c in inv.columns]
+
+    if "usaf" not in inv.columns or "wban" not in inv.columns:
+        raise RuntimeError("Unexpected ISD inventory format; expected 'usaf' and 'wban' columns.")
+
+    inv["station_id"] = inv["usaf"].astype(str).str.zfill(6) + inv["wban"].astype(str).str.zfill(5)
+
+    if country is not None and "country" in inv.columns:
+        inv = inv[inv["country"].str.upper() == country.upper()]
+
+    if stations is not None:
+        wanted = set(str(s) for s in stations)
+        inv = inv[inv["station_id"].isin(wanted)]
+
+    if start_year is not None or end_year is not None:
+        begin = pd.to_datetime(inv.get("begin")) if "begin" in inv.columns else None
+        end = pd.to_datetime(inv.get("end")) if "end" in inv.columns else None
+        if begin is not None:
+            inv = inv[begin.dt.year <= (start_year or begin.dt.year.min())]
+        if end is not None:
+            inv = inv[end.dt.year >= (end_year or end.dt.year.max())]
+
+    inv = inv.sort_values("station_id")
+
+    if max_stations is not None:
+        inv = inv.head(int(max_stations))
+
+    return inv.reset_index(drop=True)
+
+
+def _load_or_download_station_year(
+    station_id: str,
+    year: int,
+    raw_data_dir: Optional[Path],
+) -> pd.DataFrame:
+    """Fetch a single station-year dataframe, caching to disk when requested."""
+
+    if raw_data_dir is not None:
+        raw_data_dir.mkdir(parents=True, exist_ok=True)
+        parquet_path = raw_data_dir / f"{station_id}_{year}.parquet"
+        if parquet_path.exists():
+            return pd.read_parquet(parquet_path)
+
+    _require_isd()
+
+    df_year, _meta = isd.get_data(station_id, year)  # type: ignore[call-arg]
+    if not isinstance(df_year, pd.DataFrame) or df_year.empty:
+        return pd.DataFrame()
+
+    df_year = df_year.copy()
+    df_year.columns = [str(c).lower() for c in df_year.columns]
+
+    if raw_data_dir is not None:
+        parquet_path = raw_data_dir / f"{station_id}_{year}.parquet"
+        df_year.to_parquet(parquet_path)
+
+    return df_year
+
+
+def download_isd_dataset(
+    station_ids: Sequence[str],
+    years: Sequence[int],
+    raw_data_dir: Optional[PathLike] = None,
+) -> pd.DataFrame:
+    """Download the NOAA ISD subset for the requested stations and years."""
+
+    if not station_ids:
+        raise ValueError("At least one station identifier must be provided.")
+
+    years_sorted = sorted(set(int(y) for y in years))
+    if not years_sorted:
+        raise ValueError("No years specified for download.")
+
+    raw_dir = Path(raw_data_dir).expanduser() if raw_data_dir is not None else None
+
+    frames: List[pd.DataFrame] = []
+    for station_id in station_ids:
+        for year in years_sorted:
+            frame = _load_or_download_station_year(str(station_id), int(year), raw_dir)
+            if not frame.empty:
+                frames.append(frame)
+
+    if not frames:
+        raise RuntimeError("No ISD data could be retrieved for the requested configuration.")
+
+    combined = pd.concat(frames, ignore_index=True)
+    return combined
+
+
+def _clean_raw_isd_frame(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize column names and enforce datetime ordering."""
+
+    cleaned = df.copy()
+    cleaned.columns = [str(c).lower() for c in cleaned.columns]
+
+    if "date" in cleaned.columns:
+        cleaned["datetime"] = pd.to_datetime(cleaned.pop("date"), errors="coerce")
+    elif "datetime" in cleaned.columns:
+        cleaned["datetime"] = pd.to_datetime(cleaned["datetime"], errors="coerce")
+    else:
+        raise ValueError("Raw ISD dataframe must contain a 'date' or 'datetime' column.")
+
+    cleaned = cleaned.dropna(subset=["datetime"])
+
+    if "station" not in cleaned.columns:
+        raise ValueError("Raw ISD dataframe must contain a 'station' column.")
+
+    cleaned["station"] = cleaned["station"].astype(str)
+    cleaned = cleaned.sort_values(["station", "datetime"]).reset_index(drop=True)
+
+    return cleaned
+
+
+def _build_station_panels(
+    df: pd.DataFrame,
+    feature_columns: Sequence[str],
+    freq: str,
+    min_coverage: float,
+) -> Dict[str, pd.DataFrame]:
+    """Create a dictionary mapping station identifiers to aligned feature panels."""
+
+    df = _clean_raw_isd_frame(df)
+
+    feature_cols = [str(c).lower() for c in feature_columns]
+    if TARGET_COLUMN not in feature_cols:
+        raise ValueError(f"Target column '{TARGET_COLUMN}' must be included in feature_columns.")
+
+    available_features = [c for c in feature_cols if c in df.columns]
+    if len(available_features) != len(feature_cols):
+        missing = set(feature_cols) - set(available_features)
+        raise ValueError(f"Missing expected ISD feature columns: {sorted(missing)}")
+
+    panels: Dict[str, pd.DataFrame] = {}
+    for station_id, group in df.groupby("station", sort=False):
+        station_df = group.set_index("datetime")[available_features]
+        station_df = station_df.apply(pd.to_numeric, errors="coerce")
+        station_df = station_df.resample(freq).mean()
+        station_df = station_df.ffill()
+        coverage = 1.0 - station_df.isna().any(axis=1).mean() if len(station_df) else 0.0
+        if coverage < min_coverage:
+            continue
+        station_df = station_df.dropna()
+        if not station_df.empty:
+            panels[str(station_id)] = station_df.astype(np.float32)
+
+    if not panels:
+        raise RuntimeError("All stations were filtered out during panel construction.")
+
+    return panels
+
+
+class _NormStatsAccumulator:
+    """Accumulate normalization statistics for per-station or global modes."""
+
+    def __init__(self, num_assets: int, feature_dim: int, per_asset: bool) -> None:
+        self.per_asset = per_asset
+        self.num_assets = int(num_assets)
+        self.feature_dim = int(feature_dim)
+
+        if per_asset:
+            self.mean_x: List[Optional[np.ndarray]] = [None] * self.num_assets
+            self.std_x: List[Optional[np.ndarray]] = [None] * self.num_assets
+            self.mean_y: List[Optional[float]] = [None] * self.num_assets
+            self.std_y: List[Optional[float]] = [None] * self.num_assets
+        else:
+            self.count = 0
+            self.sum_x = np.zeros(self.feature_dim, dtype=np.float64)
+            self.sumsq_x = np.zeros(self.feature_dim, dtype=np.float64)
+            self.total_y = 0.0
+            self.total_y_sq = 0.0
+            self.total_y_count = 0
+
+    def update(self, aid: int, features: np.ndarray, targets: np.ndarray) -> None:
+        if self.per_asset:
+            f64 = features.astype(np.float64, copy=False)
+            t64 = targets.astype(np.float64, copy=False)
+            mx = f64.mean(axis=0)
+            sx = f64.std(axis=0)
+            sx = np.where(sx == 0.0, 1.0, sx)
+            my = float(t64.mean()) if t64.size else 0.0
+            sy = float(t64.std()) if t64.size else 1.0
+            sy = 1.0 if sy == 0.0 else sy
+            self.mean_x[aid] = mx.reshape(1, 1, -1).astype(np.float32)
+            self.std_x[aid] = sx.reshape(1, 1, -1).astype(np.float32)
+            self.mean_y[aid] = my
+            self.std_y[aid] = sy
+        else:
+            f64 = features.astype(np.float64, copy=False)
+            t64 = targets.astype(np.float64, copy=False)
+            self.count += f64.shape[0]
+            self.sum_x += f64.sum(axis=0)
+            self.sumsq_x += np.square(f64).sum(axis=0)
+            self.total_y += float(t64.sum())
+            self.total_y_sq += float(np.square(t64).sum())
+            self.total_y_count += t64.shape[0]
+
+    def finalize(self, assets: Iterable[str]) -> Dict[str, object]:
+        assets_list = list(assets)
+        if self.per_asset:
+            if not all(
+                m is not None and s is not None and my is not None and sy is not None
+                for m, s, my, sy in zip(self.mean_x, self.std_x, self.mean_y, self.std_y)
+            ):
+                raise RuntimeError("Normalization statistics missing for some assets.")
+            return {
+                "per_ticker": True,
+                "assets": assets_list,
+                "mean_x": [mx.tolist() for mx in self.mean_x],
+                "std_x": [sx.tolist() for sx in self.std_x],
+                "mean_y": [float(my) for my in self.mean_y],
+                "std_y": [float(sy) for sy in self.std_y],
+            }
+
+        if self.count == 0:
+            raise RuntimeError("Unable to compute normalization statistics (no samples).")
+
+        mean_x = (self.sum_x / self.count).astype(np.float32)
+        var_x = (self.sumsq_x / self.count) - np.square(mean_x.astype(np.float64))
+        var_x = np.maximum(var_x, 1e-12)
+        std_x = np.sqrt(var_x).astype(np.float32)
+        std_x[std_x == 0.0] = 1.0
+
+        if self.total_y_count > 0:
+            mean_y = float(self.total_y / self.total_y_count)
+            var_y = max((self.total_y_sq / self.total_y_count) - (mean_y ** 2), 1e-12)
+            std_y = float(np.sqrt(var_y))
+            std_y = 1.0 if std_y == 0.0 else std_y
+        else:
+            mean_y = 0.0
+            std_y = 1.0
+
+        return {
+            "per_ticker": False,
+            "assets": assets_list,
+            "mean_x": mean_x.reshape(1, 1, -1).tolist(),
+            "std_x": std_x.reshape(1, 1, -1).tolist(),
+            "mean_y": mean_y,
+            "std_y": std_y,
+        }
+
+
+def prepare_isd_cache(cfg: ISDCacheConfig) -> Mapping[str, List[str]]:
+    """Prepare the compact cache for the NOAA ISD dataset."""
+
+    if cfg.window <= 0:
+        raise ValueError("window must be positive")
+    if cfg.horizon < 0:
+        raise ValueError("horizon must be non-negative")
+    if not cfg.years:
+        raise ValueError("At least one year must be specified in cfg.years")
+
+    keep_time_meta = cfg.keep_time_meta.lower()
+    if keep_time_meta not in {"full", "end", "none"}:
+        raise ValueError("keep_time_meta must be one of {'full', 'end', 'none'}")
+
+    feature_columns = list(dict.fromkeys((cfg.feature_columns or DEFAULT_FEATURE_COLUMNS)))
+    feature_columns = [c.lower() for c in feature_columns]
+
+    station_inventory = list_isd_stations(
+        country=cfg.country,
+        start_year=min(cfg.years),
+        end_year=max(cfg.years),
+        stations=cfg.stations,
+        max_stations=cfg.max_stations,
+    )
+
+    if station_inventory.empty:
+        raise RuntimeError("No ISD stations matched the requested filters.")
+
+    station_ids = station_inventory["station_id"].astype(str).tolist()
+
+    raw_dir = Path(cfg.raw_data_dir).expanduser().resolve() if cfg.raw_data_dir else None
+    raw_df = download_isd_dataset(station_ids=station_ids, years=cfg.years, raw_data_dir=raw_dir)
+
+    panels = _build_station_panels(
+        raw_df,
+        feature_columns=feature_columns,
+        freq=cfg.freq,
+        min_coverage=cfg.min_coverage,
+    )
+
+    assets = sorted(panels.keys())
+    asset_to_id = {asset: idx for idx, asset in enumerate(assets)}
+
+    feature_cols = list(feature_columns)
+    target_col = TARGET_COLUMN
+
+    data_dir = Path(cfg.data_dir).expanduser().resolve()
+    paths = CachePaths.from_dir(data_dir)
+    if cfg.overwrite and paths.cache_root.exists():
+        import shutil
+
+        shutil.rmtree(paths.cache_root)
+    paths.ensure()
+
+    pairs: List[np.ndarray] = []
+    end_times: List[np.ndarray] = []
+    start_times: List[np.datetime64] = []
+    stop_times: List[np.datetime64] = []
+
+    feature_dim = len(feature_cols)
+    norm_acc = _NormStatsAccumulator(
+        num_assets=len(assets),
+        feature_dim=feature_dim,
+        per_asset=cfg.normalize_per_station,
+    )
+
+    for asset in assets:
+        aid = asset_to_id[asset]
+        panel = panels[asset][feature_cols]
+        total_rows = panel.shape[0]
+        if total_rows < cfg.window + cfg.horizon:
+            raise ValueError(
+                f"Station '{asset}' has insufficient history for the requested window/horizon."
+            )
+
+        features = panel.to_numpy(dtype=np.float32, copy=True)
+        targets = panel[target_col].to_numpy(dtype=np.float32, copy=True)
+        times = panel.index.to_numpy(dtype="datetime64[ns]")
+
+        np.save(paths.features / f"{aid}.npy", features.astype(np.float16, copy=False))
+        np.save(paths.targets / f"{aid}.npy", targets.astype(np.float16, copy=False))
+        np.save(paths.times / f"{aid}.npy", times)
+
+        norm_acc.update(aid, features, targets)
+
+        max_start = total_rows - (cfg.window + cfg.horizon) + 1
+        if max_start <= 0:
+            continue
+        starts = np.arange(0, max_start, dtype=np.int32)
+        window_end_times = times[starts + cfg.window - 1].astype("datetime64[ns]")
+        pairs.append(np.stack([np.full_like(starts, aid), starts], axis=1))
+        end_times.append(window_end_times)
+        start_times.append(times[0])
+        stop_times.append(times[-1])
+
+    if not pairs:
+        raise RuntimeError("No valid context windows available across stations.")
+
+    global_pairs = np.concatenate(pairs, axis=0).astype(np.int32)
+    global_end_times = np.concatenate(end_times, axis=0).astype("datetime64[ns]")
+    np.save(paths.windows / "global_pairs.npy", global_pairs)
+    np.save(paths.windows / "end_times.npy", global_end_times)
+
+    norm_stats = norm_acc.finalize(assets)
+
+    dataset_start = min(start_times).astype("datetime64[s]") if start_times else None
+    dataset_end = max(stop_times).astype("datetime64[s]") if stop_times else None
+
+    meta = {
+        "dataset": "nnoa_isd",
+        "format": "indexcache_v1",
+        "assets": assets,
+        "asset2id": asset_to_id,
+        "feature_cols": feature_cols,
+        "target_col": target_col,
+        "window": int(cfg.window),
+        "horizon": int(cfg.horizon),
+        "keep_time_meta": keep_time_meta,
+        "normalize_per_ticker": cfg.normalize_per_station,
+        "clamp_sigma": cfg.clamp_sigma,
+        "freq": cfg.freq,
+        "start": str(dataset_start) if dataset_start is not None else None,
+        "end": str(dataset_end) if dataset_end is not None else None,
+    }
+
+    with paths.meta.open("w") as f:
+        json.dump(meta, f, indent=2)
+
+    with paths.norm_stats.open("w") as f:
+        json.dump(norm_stats, f, indent=2)
+
+    return {"assets": assets, "feature_cols": feature_cols}
+
+
+def load_isd_dataloaders_with_ratio_split(
+    data_dir: PathLike,
+    **loader_kwargs,
+):
+    """Wrapper around the financial ratio-split loader for ISD datasets."""
+
+    return _load_fin_ratio_split(data_dir=data_dir, **loader_kwargs)
+
+
+def _validate_isd_cache(paths: CachePaths) -> Dict[str, object]:
+    """Read and validate the cache metadata, returning the parsed JSON."""
+
+    if not paths.meta.exists():
+        raise FileNotFoundError(
+            f"Cache meta file not found at '{paths.meta}'. Did you run prepare_isd_cache()?"
+        )
+
+    with paths.meta.open("r") as f:
+        meta: Dict[str, object] = json.load(f)
+
+    dataset = meta.get("dataset")
+    if dataset not in {"nnoa_isd", "noaa_isd"}:
+        raise ValueError(
+            f"The cache located at '{paths.cache_root}' does not correspond to the NOAA ISD dataset."
+        )
+
+    return meta
+
+
+def run_experiment(
+    data_dir: PathLike,
+    K: int,
+    H: int,
+    *,
+    ratios=(0.7, 0.1, 0.2),
+    per_asset: bool = True,
+    date_batching: bool = True,
+    coverage: float = 0.85,
+    dates_per_batch: int = 30,
+    batch_size: int = 64,
+    norm: str = "train_only",
+    reindex: bool = True,
+    shuffle_train: bool = True,
+    num_workers: int = 0,
+    pin_memory: Optional[bool] = None,
+):
+    """Build train/val/test loaders for a prepared ISD cache.
+
+    Mirrors :func:`Dataset.fin_dataset.run_experiment` so downstream training
+    code can switch datasets with minimal friction.
+    """
+
+    paths = CachePaths.from_dir(data_dir)
+    meta = _validate_isd_cache(paths)
+    base_window = int(meta.get("window", K))
+    base_horizon = int(meta.get("horizon", H))
+    if K > base_window or H > base_horizon:
+        raise ValueError(
+            "Requested (window, horizon) exceed the cached configuration. "
+            "Re-run prepare_isd_cache with larger values first."
+        )
+
+    if reindex:
+        _rebuild_window_index_only(
+            data_dir,
+            window=K,
+            horizon=H,
+            update_meta=False,
+            backup_old=False,
+        )
+
+    train_dl, val_dl, test_dl, lengths = load_isd_dataloaders_with_ratio_split(
+        data_dir=data_dir,
+        train_ratio=ratios[0],
+        val_ratio=ratios[1],
+        test_ratio=ratios[2],
+        batch_size=batch_size,
+        regression=True,
+        per_asset=per_asset,
+        norm_scope=norm,
+        date_batching=date_batching,
+        coverage_per_window=coverage,
+        dates_per_batch=dates_per_batch,
+        window=K,
+        horizon=H,
+        shuffle_train=shuffle_train,
+        num_workers=num_workers,
+        pin_memory=pin_memory,
+    )
+
+    return train_dl, val_dl, test_dl, lengths
+
+
+__all__ = [
+    "ISDCacheConfig",
+    "list_isd_stations",
+    "download_isd_dataset",
+    "prepare_isd_cache",
+    "load_isd_dataloaders_with_ratio_split",
+    "run_experiment",
 ]
-
-# Get the list of station IDs to download
-station_ids = uk_stations_2022['usaf'] + uk_stations_2022['wban']
-print(f"Found {len(station_ids)} active stations in Great Britain for 2022.")
-print("Example station IDs:", station_ids.head().tolist())
-
-
-def download_isd_subset(station_ids, start_year, end_year):
-    """
-    Downloads data for a list of station IDs over a year range.
-    """
-    df_list = []
-
-    # Use tqdm to show progress as this can be slow
-    for station_id in tqdm(station_ids, desc="Downloading station data"):
-        try:
-            # The library fetches data year by year
-            for year in range(start_year, end_year + 1):
-                df_station, _ = isd.get_data(station_id, year)
-                df_list.append(df_station)
-        except Exception as e:
-            print(f"Could not fetch data for station {station_id}: {e}")
-
-    if not df_list:
-        raise ValueError("No data could be downloaded for the selected stations.")
-
-    return pd.concat(df_list, ignore_index=True)
-
-
-# Download the data for our selected stations for the year 2022
-df_raw = download_isd_subset(station_ids.tolist(), 2022, 2022)
-
-print("\nCombined DataFrame shape:", df_raw.shape)
-print("Combined DataFrame head:")
-print(df_raw.head())
-
-
-def clean_and_panel_isd_data(df: pd.DataFrame) -> pd.DataFrame:
-    """
-    Cleans and pivots the raw ISD data into a multivariate panel.
-    """
-    # 1. Select a subset of useful feature channels
-    feature_cols = [
-        'station', 'date', 'temperature', 'dew_point',
-        'sea_level_pressure', 'wind_speed', 'precipitation'
-    ]
-    df = df[feature_cols]
-
-    # 2. Create a proper datetime index
-    df['datetime'] = pd.to_datetime(df['date'])
-    df = df.set_index('datetime').drop('date', axis=1)
-
-    # 3. Handle missing values using forward-fill within each station group
-    # The library already uses NaNs for missing data
-    df = df.groupby('station').ffill()
-
-    # 4. Pivot to create the final panel format
-    df_panel = df.pivot(columns='station')
-
-    # Reorder columns for better readability
-    df_panel = df_panel.swaplevel(0, 1, axis=1).sort_index(axis=1)
-
-    return df_panel
-
-
-# Process the raw data
-df_panel = clean_and_panel_isd_data(df_raw.copy())
-
-print("\n✅ Processing Complete! Final Panel DataFrame head:")
-print(df_panel.head())
-print("\nExample of irregularity (NaN values where stations were offline):")
-print(df_panel.loc['2022-07-01 00:00:00':'2022-07-01 05:00:00', pd.IndexSlice[:, 'temperature']])


### PR DESCRIPTION
## Summary
- replace the previous ad-hoc NOAA ISD script with a cache-building module that mirrors the fin_dataset and BMS dataset APIs
- add helpers for station inventory filtering, cached downloads, normalization statistics, and train/val/test loader construction

## Testing
- python -m compileall Dataset/nnoa_isd_dataset.py

------
https://chatgpt.com/codex/tasks/task_e_68e279daee788329bd449acd1b80b71e